### PR TITLE
Dr/fix imports and flush

### DIFF
--- a/src/LaunchDarkly.Client/EventProcessor.cs
+++ b/src/LaunchDarkly.Client/EventProcessor.cs
@@ -40,6 +40,7 @@ namespace LaunchDarkly.Client
 
         public void Dispose()
         {
+            Flush();
             _queue.CompleteAdding();
             _timer.Dispose();
             _queue.Dispose();

--- a/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
+++ b/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
@@ -37,8 +37,8 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/src/LaunchDarkly.Client/LaunchDarkly.Client.nuspec
+++ b/src/LaunchDarkly.Client/LaunchDarkly.Client.nuspec
@@ -14,5 +14,8 @@
     <releaseNotes>Switch to asynchronous HTTP client</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>Feature Configuration</tags>
+     <dependencies>
+      <dependency id="Newtonsoft.Json" version="8.0.3" />
+    </dependencies> 
   </metadata>
 </package>

--- a/src/LaunchDarkly.Client/packages.config
+++ b/src/LaunchDarkly.Client/packages.config
@@ -5,6 +5,6 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net451" />
   <package id="NuGet.CommandLine" version="3.4.3" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/LaunchDarkly.Tests/packages.config
+++ b/src/LaunchDarkly.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net451" userInstalled="true" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net451" userInstalled="true" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net451" userInstalled="true" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net451" userInstalled="true" />
   <package id="NLog" version="4.3.1" targetFramework="net451" userInstalled="true" />
   <package id="NLog.Config" version="4.3.1" targetFramework="net451" userInstalled="true" />
   <package id="NLog.Schema" version="4.3.0" targetFramework="net451" userInstalled="true" />


### PR DESCRIPTION
-Added flush call when disposing event processor
-Changed mentions of Newtonsoft.json dependency to match what we had when we were using 6.0.x (we're now using 8.0.3 and the update inadvertently changed some xml)
-Added explicit Newtonsoft.json dependency in nuspec file (this fixes the problem)