### PR TITLE
Flatten AggregateException to improve log message

### DIFF
--- a/src/LaunchDarkly.Client/PollingProcessor.cs
+++ b/src/LaunchDarkly.Client/PollingProcessor.cs
@@ -54,6 +54,9 @@ namespace LaunchDarkly.Client
                     Logger.Info("Initialized LaunchDarkly Polling Processor.");
                 }
             }
+            catch ( AggregateException ex ) {
+                Logger.Error( string.Format( "Error Updating features: '{0}'", ex.Flatten().Message ) );
+            }
             catch (Exception ex)
             {
                 Logger.Error(string.Format("Error Updating features: '{0}'", ex.Message));


### PR DESCRIPTION
At the moment we are experiencing such kind of log messages which don't help at all:
INFO  2016-09-30 01:57:20 - Starting LaunchDarkly PollingProcessor with interval: 120000 milliseconds
INFO  2016-09-30 01:57:20 - Waiting up to 5000 milliseconds for LaunchDarkly client to start..
ERROR 2016-09-30 01:57:20 - Error Updating features: `'One or more errors occurred.'`
ERROR 2016-09-30 01:58:06 - Error Updating features: 'One or more errors occurred.'
ERROR 2016-09-30 01:59:20 - Error Updating features: 'One or more errors occurred.'
ERROR 2016-09-30 02:00:06 - Error Updating features: 'One or more errors occurred.'
ERROR 2016-09-30 02:01:20 - Error Updating features: 'One or more errors occurred.'

Should I update version in AssemblyInfo.cs?