### PR TITLE
Better logging when http requests time out, prepare for 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the LaunchDarkly .NET SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [3.0.0] - 2016-10-27
+### Changed
+- Addresses Unnecesary Lock contention when polling: https://github.com/launchdarkly/.net-client/issues/18
+- Logging framework: Now using Microsoft.Extensions.Logging
+- No longer depending on ASP.NET: https://github.com/launchdarkly/.net-client/issues/8
+
+### Added
+- Support for .NET core: https://github.com/launchdarkly/.net-client/issues/9
+- Http client now has a request timeout: https://github.com/launchdarkly/.net-client/issues/27
+
+### Deprecated
+- File-based configuration override option has been removed
+
 ## [2.0.3] - 2016-10-10
 ### Changed
 - Code cleanup

--- a/src/LaunchDarkly.Client/EventProcessor.cs
+++ b/src/LaunchDarkly.Client/EventProcessor.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;

--- a/src/LaunchDarkly.Client/Util.cs
+++ b/src/LaunchDarkly.Client/Util.cs
@@ -14,9 +14,15 @@ namespace LaunchDarkly.Client
         internal static string ExceptionMessage(Exception e)
         {
             var msg = e.Message;
+
+            if (e is System.Threading.Tasks.TaskCanceledException)
+            {
+                msg += " (Likely due to a http request timeout)";
+            }
+
             if (e.InnerException != null)
             {
-                return msg + " with inner excpetion: " + e.InnerException.Message;
+                return msg + " with inner exception: " + e.InnerException.Message;
             }
             return msg;
         }


### PR DESCRIPTION
Addresses: https://github.com/launchdarkly/.net-client/issues/30