### PR TITLE
Feature store persistence

### DIFF
--- a/src/LaunchDarkly.Client/IFeatureStore.cs
+++ b/src/LaunchDarkly.Client/IFeatureStore.cs
@@ -5,6 +5,7 @@ namespace LaunchDarkly.Client
 {
     interface IFeatureStore
     {
+        Task LoadPersistedDataAsync();
         string VersionIdentifier { get; }
         Task<bool> WaitForInitializationAsync();
         FeatureFlag Get(string key);

--- a/src/LaunchDarkly.Client/IFeatureStore.cs
+++ b/src/LaunchDarkly.Client/IFeatureStore.cs
@@ -9,8 +9,6 @@ namespace LaunchDarkly.Client
         FeatureFlag Get(string key);
         IDictionary<string, FeatureFlag> All();
         void Init(IDictionary<string, FeatureFlag> features);
-        void Delete(string key, int version);
-        void Upsert(string key, FeatureFlag featureFlag);
         bool Initialized();
     }
 }

--- a/src/LaunchDarkly.Client/IFeatureStore.cs
+++ b/src/LaunchDarkly.Client/IFeatureStore.cs
@@ -5,10 +5,11 @@ namespace LaunchDarkly.Client
 {
     interface IFeatureStore
     {
+        string VersionIdentifier { get; }
         Task<bool> WaitForInitializationAsync();
         FeatureFlag Get(string key);
         IDictionary<string, FeatureFlag> All();
-        void Init(IDictionary<string, FeatureFlag> features);
+        void Init(IDictionary<string, FeatureFlag> features, string versionIdentifier);
         bool Initialized();
     }
 }

--- a/src/LaunchDarkly.Client/IFeatureStore.cs
+++ b/src/LaunchDarkly.Client/IFeatureStore.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace LaunchDarkly.Client
 {
     interface IFeatureStore
     {
+        Task<bool> WaitForInitializationAsync();
         FeatureFlag Get(string key);
         IDictionary<string, FeatureFlag> All();
         void Init(IDictionary<string, FeatureFlag> features);

--- a/src/LaunchDarkly.Client/IUpdateProcessor.cs
+++ b/src/LaunchDarkly.Client/IUpdateProcessor.cs
@@ -5,7 +5,6 @@ namespace LaunchDarkly.Client
 {
     internal interface IUpdateProcessor : IDisposable
     {
-        TaskCompletionSource<bool> Start();
-        bool Initialized();
+        void Start();
     }
 }

--- a/src/LaunchDarkly.Client/InMemoryFeatureStore.cs
+++ b/src/LaunchDarkly.Client/InMemoryFeatureStore.cs
@@ -15,7 +15,7 @@ namespace LaunchDarkly.Client
         private readonly IDictionary<string, FeatureFlag> Features = new Dictionary<string, FeatureFlag>();
         private int _initialized = UNINITIALIZED;
         private readonly TaskCompletionSource<bool> _initTask = new TaskCompletionSource<bool>();
-
+        
         Task<bool> IFeatureStore.WaitForInitializationAsync()
         {
             return _initTask.Task;
@@ -89,50 +89,7 @@ namespace LaunchDarkly.Client
                 RwLock.ExitWriteLock();
             }
         }
-
-        void IFeatureStore.Delete(string key, int version)
-        {
-            try
-            {
-                RwLock.TryEnterWriteLock(RwLockMaxWaitMillis);
-                FeatureFlag f;
-                if (Features.TryGetValue(key, out f) && f.Version < version)
-                {
-                    f.Deleted = true;
-                    f.Version = version;
-                    Features[key] = f;
-                }
-                else if (f == null)
-                {
-                    f = new FeatureFlag();
-                    f.Deleted = true;
-                    f.Version = version;
-                    Features[key] = f;
-                }
-            }
-            finally
-            {
-                RwLock.ExitWriteLock();
-            }
-        }
-
-        void IFeatureStore.Upsert(string key, FeatureFlag featureFlag)
-        {
-            try
-            {
-                RwLock.TryEnterWriteLock(RwLockMaxWaitMillis);
-                FeatureFlag old;
-                if (!Features.TryGetValue(key, out old) || old.Version < featureFlag.Version)
-                {
-                    Features[key] = featureFlag;
-                }
-            }
-            finally
-            {
-                RwLock.ExitWriteLock();
-            }
-        }
-
+        
         bool IFeatureStore.Initialized()
         {
             try

--- a/src/LaunchDarkly.Client/LdClient.cs
+++ b/src/LaunchDarkly.Client/LdClient.cs
@@ -30,10 +30,11 @@ namespace LaunchDarkly.Client
 
             var featureRequestor = new FeatureRequestor(config);
             _updateProcessor = new PollingProcessor(config, featureRequestor, _featureStore);
-            var initTask = _updateProcessor.Start();
+            var initTask = _featureStore.WaitForInitializationAsync();
+            _updateProcessor.Start();
             Logger.LogInformation("Waiting up to " + _configuration.StartWaitTime.TotalMilliseconds +
                                   " milliseconds for LaunchDarkly client to start..");
-            var unused = initTask.Task.Wait(_configuration.StartWaitTime);
+            var unused = initTask.Wait(_configuration.StartWaitTime);
         }
 
         public LdClient(Configuration config) : this(config, new EventProcessor(config))
@@ -46,7 +47,7 @@ namespace LaunchDarkly.Client
 
         public bool Initialized()
         {
-            return IsOffline() || _updateProcessor.Initialized();
+            return IsOffline() || _featureStore.Initialized();
         }
 
         public bool IsOffline()

--- a/src/LaunchDarkly.Client/PollingProcessor.cs
+++ b/src/LaunchDarkly.Client/PollingProcessor.cs
@@ -8,14 +8,11 @@ namespace LaunchDarkly.Client
     internal class PollingProcessor : IUpdateProcessor
     {
         private static readonly ILogger Logger = LdLogger.CreateLogger<PollingProcessor>();
-        private static int UNINITIALIZED = 0;
-        private static int INITIALIZED = 1;
         private readonly Configuration _config;
         private readonly FeatureRequestor _featureRequestor;
         private readonly IFeatureStore _featureStore;
-        private int _initialized = UNINITIALIZED;
-        private readonly TaskCompletionSource<bool> _initTask;
-        private bool _disposed;
+        private readonly CancellationTokenSource _stopCts = new CancellationTokenSource();
+
 
 
         internal PollingProcessor(Configuration config, FeatureRequestor featureRequestor, IFeatureStore featureStore)
@@ -23,28 +20,27 @@ namespace LaunchDarkly.Client
             _config = config;
             _featureRequestor = featureRequestor;
             _featureStore = featureStore;
-            _initTask = new TaskCompletionSource<bool>();
         }
+        
 
-        bool IUpdateProcessor.Initialized()
-        {
-            return _initialized == INITIALIZED;
-        }
-
-        TaskCompletionSource<bool> IUpdateProcessor.Start()
+        void IUpdateProcessor.Start()
         {
             Logger.LogInformation("Starting LaunchDarkly PollingProcessor with interval: " +
                                   (int) _config.PollingInterval.TotalMilliseconds + " milliseconds");
-            Task.Run(() => UpdateTaskLoopAsync());
-            return _initTask;
+            var stopToken = _stopCts.Token;
+            Task.Run(() => UpdateTaskLoopAsync(stopToken));
         }
 
-        private async Task UpdateTaskLoopAsync()
+        private async Task UpdateTaskLoopAsync(CancellationToken stopToken)
         {
-            while (!_disposed)
+            while (!stopToken.IsCancellationRequested)
             {
                 await UpdateTaskAsync();
-                await Task.Delay(_config.PollingInterval);
+                try
+                {
+                    await Task.Delay(_config.PollingInterval, stopToken);
+                }
+                catch (OperationCanceledException) { }
             }
         }
 
@@ -56,13 +52,6 @@ namespace LaunchDarkly.Client
                 if (allFeatures != null)
                 {
                     _featureStore.Init(allFeatures);
-
-                    //We can't use bool in CompareExchange because it is not a reference type.
-                    if (Interlocked.CompareExchange(ref _initialized, INITIALIZED, UNINITIALIZED) == 0)
-                    {
-                        _initTask.SetResult(true);
-                        Logger.LogInformation("Initialized LaunchDarkly Polling Processor.");
-                    }
                 }
             }
             catch (AggregateException ex)
@@ -79,7 +68,7 @@ namespace LaunchDarkly.Client
         void IDisposable.Dispose()
         {
             Logger.LogInformation("Stopping LaunchDarkly PollingProcessor");
-            _disposed = true;
+            _stopCts.Cancel();
         }
     }
 }

--- a/src/LaunchDarkly.Client/PollingProcessor.cs
+++ b/src/LaunchDarkly.Client/PollingProcessor.cs
@@ -48,10 +48,10 @@ namespace LaunchDarkly.Client
         {
             try
             {
-                var allFeatures = await _featureRequestor.MakeAllRequestAsync();
-                if (allFeatures != null)
+                var allFeatures = await _featureRequestor.MakeAllRequestAsync(_featureStore.VersionIdentifier);
+                if (allFeatures.FeatureFlags != null)
                 {
-                    _featureStore.Init(allFeatures);
+                    _featureStore.Init(allFeatures.FeatureFlags, allFeatures.VersionIdentifier);
                 }
             }
             catch (AggregateException ex)

--- a/test/LaunchDarkly.Tests/PersistenceTests.cs
+++ b/test/LaunchDarkly.Tests/PersistenceTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using LaunchDarkly.Client;
+using Xunit;
+
+namespace LaunchDarkly.Tests
+{
+    public class PersistenceTests
+    {
+        private class TestPersistenceStore : InMemoryFeatureStore
+        {
+            protected override bool IsPersisted => true;
+            public string PersistedData { get; set; }
+
+            public int StoreCount { get; set; }
+            public int LoadCount { get; set; }
+            protected override Task<string> LoadPersistedDataAsync()
+            {
+                LoadCount++;
+                return Task.FromResult(PersistedData);
+            }
+
+            protected override Task StorePersistedDataAsync(string data)
+            {
+                PersistedData = data;
+                StoreCount++;
+                return Task.FromResult(0);
+            }
+        }
+
+
+        [Fact]
+        public void PersistedDataShouldRehydrate()
+        {
+            var testee = new TestPersistenceStore();
+            var asFeatureStore = testee as IFeatureStore;
+            asFeatureStore.LoadPersistedDataAsync().Wait();
+            Assert.Equal(1, testee.LoadCount);
+            Assert.Equal(0, testee.StoreCount);
+
+            asFeatureStore.Init(new Dictionary<string, FeatureFlag> { { "test", new FeatureFlag("test", 1, false, new List<Prerequisite>(), "test", new List<Target>(), new List<Rule>(), null, null, null, false) } }, "test");
+            Thread.Sleep(100);
+
+            Assert.Equal(1, testee.LoadCount);
+            Assert.Equal(1, testee.StoreCount);
+
+            var persistedData = testee.PersistedData;
+
+            testee = new TestPersistenceStore {PersistedData = persistedData};
+            asFeatureStore = testee as IFeatureStore;
+            asFeatureStore.LoadPersistedDataAsync().Wait();
+            Assert.Equal(1, testee.LoadCount);
+            Assert.Equal(0, testee.StoreCount);
+            Assert.Equal("test", asFeatureStore.VersionIdentifier);
+            Assert.NotNull(asFeatureStore.Get("test"));
+        }
+    }
+}

--- a/test/LaunchDarkly.Tests/project.json
+++ b/test/LaunchDarkly.Tests/project.json
@@ -7,7 +7,6 @@
       "target": "project",
       "version": ""
     },
-    "Microsoft.NETCore.App": "1.1.0",
     "xunit": "2.2.0-beta2-build3300"
   },
   "frameworks": {
@@ -15,7 +14,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0"
+          "version": "1.1.0"
         }
       }
     }


### PR DESCRIPTION
This fixes https://github.com/launchdarkly/.net-client/issues/37.

The idea is to be able to use persisted feature flags in a local db or on disk to enable offline scenarios.
The PR is made of several commits to make it easier to understand the code changes.