### PR TITLE
Fix user name attribute overwriting the lastName attribute

### DIFF
--- a/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
+++ b/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>3.2.1</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LaunchDarkly.Client</AssemblyName>


### PR DESCRIPTION
This PR fixes a bug where `User.AndName` was updating the `LastName` property and not `Name`.