### PR TITLE
Move from .NET Standard 1.6 to 1.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Mac OS:
 1. Make sure you can build and run tests from command line:
 
 ```
-dotnet build src/LaunchDarkly.Client -f netstandard1.6
+dotnet build src/LaunchDarkly.Client -f netstandard1.4
 dotnet test test/LaunchDarkly.Tests/LaunchDarkly.Tests.csproj
 ```
 

--- a/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
+++ b/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>3.3.2</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.4;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>LaunchDarkly.Client</AssemblyName>
     <OutputType>Library</OutputType>
@@ -45,5 +45,10 @@
     <AssemblyOriginatorKeyFile>../../LaunchDarkly.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.4|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NETSTANDARD1_4</DefineConstants>
+    <OutputPath>bin\Debug\netstandard1.4\</OutputPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Since this client is an SDK that is being consumed by other clients, we should support the minimum version that the APIs we access allow us to support, allowing the most number of users to use this SDK.

Since this SDK was previously compiled into .NET Standard 1.6, UWP apps could not consume this (UWP apps support .NET Standard 1.4).

This PR simply changes the target of .NET standard to be .NET standard 1.4, so it can be consumed in UWP apps today.

Addresses issue #52 