### PR TITLE
Exposing the default EventProcessor via LdStoreEventsFactory

### DIFF
--- a/src/LaunchDarkly.Client/EventProcessor.cs
+++ b/src/LaunchDarkly.Client/EventProcessor.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace LaunchDarkly.Client
 {
-    internal sealed class EventProcessor : IDisposable, IStoreEvents
+    internal sealed class EventProcessor : IStoreEvents
     {
         private static readonly ILogger Logger = LdLogger.CreateLogger<EventProcessor>();
 

--- a/src/LaunchDarkly.Client/IStoreEvents.cs
+++ b/src/LaunchDarkly.Client/IStoreEvents.cs
@@ -1,6 +1,8 @@
-﻿namespace LaunchDarkly.Client
+﻿using System;
+
+namespace LaunchDarkly.Client
 {
-    public interface IStoreEvents
+    public interface IStoreEvents : IDisposable
     {
         void Add(Event eventToLog);
         void Flush();

--- a/src/LaunchDarkly.Client/LdClient.cs
+++ b/src/LaunchDarkly.Client/LdClient.cs
@@ -50,7 +50,7 @@ namespace LaunchDarkly.Client
             var unused = initTask.Wait(_configuration.StartWaitTime);
         }
 
-        public LdClient(Configuration config) : this(config, new EventProcessor(config))
+        public LdClient(Configuration config) : this(config, LdStoreEventsFactory.Create(config))
         {
         }
 
@@ -258,8 +258,8 @@ namespace LaunchDarkly.Client
         {
             Logger.LogInformation("Closing LaunchDarkly client.");
             //We do not have native resource, so the boolean parameter can be ignored.
-            if (_eventStore is EventProcessor)
-                ((_eventStore) as IDisposable).Dispose();
+
+            _eventStore.Dispose();
 
             if (_updateProcessor != null)
             {

--- a/src/LaunchDarkly.Client/LdStoreEventsFactory.cs
+++ b/src/LaunchDarkly.Client/LdStoreEventsFactory.cs
@@ -1,0 +1,11 @@
+﻿
+namespace LaunchDarkly.Client
+{
+    public static class LdStoreEventsFactory
+    {
+        public static IStoreEvents Create(Configuration config)
+        {
+            return new EventProcessor(config);
+        }
+    }
+}

--- a/test/LaunchDarkly.Tests/LdClientTest.cs
+++ b/test/LaunchDarkly.Tests/LdClientTest.cs
@@ -1,4 +1,5 @@
-﻿using LaunchDarkly.Client;
+﻿using System;
+using LaunchDarkly.Client;
 using Xunit;
 
 namespace LaunchDarkly.Tests
@@ -16,6 +17,39 @@ namespace LaunchDarkly.Tests
             var user = User.WithKey("Message");
             Assert.Equal("aa747c502a898200f9e4fa21bac68136f886a0e27aec70ba06daf2e2a5cb5597", client.SecureModeHash(user));
             client.Dispose();
+        }
+
+        [Fact]
+        public void DisposableIStoreEvents()
+        {
+            Configuration config = Configuration.Default("secret");
+            config.WithOffline(true);
+
+            MockDisposableStoreEvents storeEvents = new MockDisposableStoreEvents();
+
+            using (LdClient client = new LdClient(config, storeEvents))
+            {
+            }
+
+            Assert.True(storeEvents.Disposed);
+        }
+
+        private sealed class MockDisposableStoreEvents : IStoreEvents
+        {
+            public bool Disposed { get; private set; }
+
+            void IDisposable.Dispose()
+            {
+                Disposed = true;
+            }
+
+            void IStoreEvents.Add(Event eventToLog)
+            {
+            }
+
+            void IStoreEvents.Flush()
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
We need to be able to wrap the built-in EventProcessor to add throttling.

We have an open issue with Francis Paras & John Winstead at Launch Darkly to reduce our event rate.