### PR TITLE
prepare 6.3.1 release

### DIFF
--- a/src/LaunchDarkly.ServerSdk/Interfaces/HttpConfiguration.cs
+++ b/src/LaunchDarkly.ServerSdk/Interfaces/HttpConfiguration.cs
@@ -160,9 +160,7 @@ namespace LaunchDarkly.Sdk.Server.Interfaces
         /// <returns>a client instance</returns>
         public HttpClient NewHttpClient()
         {
-            var httpClient = MessageHandler is null ?
-                new HttpClient() :
-                new HttpClient(MessageHandler, false);
+            var httpClient = HttpProperties.NewHttpClient();
             foreach (var h in DefaultHeaders)
             {
                 httpClient.DefaultRequestHeaders.Add(h.Key, h.Value);

--- a/src/LaunchDarkly.ServerSdk/Interfaces/LdClientContext.cs
+++ b/src/LaunchDarkly.ServerSdk/Interfaces/LdClientContext.cs
@@ -45,7 +45,7 @@ namespace LaunchDarkly.Sdk.Server.Interfaces
                 basic,
                 (configuration.HttpConfigurationFactory ?? Components.HttpConfiguration()).CreateHttpConfiguration(basic),
                 null,
-                new TaskExecutor("test-sender", Logs.None.Logger(""))
+                new TaskExecutor("test-sender", basic.Logger)
                 ) { }
 
         internal LdClientContext(

--- a/src/LaunchDarkly.ServerSdk/Internal/DataSources/StreamProcessor.cs
+++ b/src/LaunchDarkly.ServerSdk/Internal/DataSources/StreamProcessor.cs
@@ -117,7 +117,7 @@ namespace LaunchDarkly.Sdk.Server.Internal.DataSources
         {
             var configBuilder = EventSource.Configuration.Builder(uri)
                 .Method(HttpMethod.Get)
-                .HttpMessageHandler(httpConfig.MessageHandler)
+                .HttpMessageHandler(httpConfig.HttpProperties.NewHttpMessageHandler())
                 .ResponseStartTimeout(httpConfig.ResponseStartTimeout)
                 .InitialRetryDelay(_initialReconnectDelay)
                 .ReadTimeout(LaunchDarklyStreamReadTimeout)

--- a/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
+++ b/src/LaunchDarkly.ServerSdk/LaunchDarkly.ServerSdk.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="LaunchDarkly.Cache" Version="1.0.2" />
     <PackageReference Include="LaunchDarkly.CommonSdk" Version="5.4.0" />
     <PackageReference Include="LaunchDarkly.EventSource" Version="4.1.3" />
-    <PackageReference Include="LaunchDarkly.InternalSdk" Version="2.2.0" />
+    <PackageReference Include="LaunchDarkly.InternalSdk" Version="2.3.0" />
     <PackageReference Include="LaunchDarkly.JsonStream" Version="1.0.3" />
     <PackageReference Include="LaunchDarkly.Logging" Version="1.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />

--- a/test/LaunchDarkly.ServerSdk.Tests/Internal/BigSegments/BigSegmentsStoreWrapperTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/Internal/BigSegments/BigSegmentsStoreWrapperTest.cs
@@ -197,7 +197,12 @@ namespace LaunchDarkly.Sdk.Server.Internal.BigSegments
                 SetStoreStatusError(new Exception("sorry"));
 
                 var status2 = statuses.ExpectValue();
-                Assert.False(status2.Available);
+                if (status2.Available)
+                {
+                    // depending on timing, we might or might not receive an initial update of Available = true
+                    status2 = statuses.ExpectValue();
+                    Assert.False(status2.Available);
+                }
                 Assert.Equal(status2, sw.GetStatus());
 
                 SetStoreTimestamp(UnixMillisecondTime.Now);

--- a/test/LaunchDarkly.ServerSdk.Tests/Internal/Model/DataSetBuilder.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/Internal/Model/DataSetBuilder.cs
@@ -13,6 +13,8 @@ namespace LaunchDarkly.Sdk.Server.Internal.Model
         private readonly Dictionary<string, Segment> _segments =
             new Dictionary<string, Segment>();
 
+        public static FullDataSet<ItemDescriptor> Empty => new DataSetBuilder().Build();
+
         internal DataSetBuilder Flags(params FeatureFlag[] flags)
         {
             foreach (var flag in flags)
@@ -63,5 +65,30 @@ namespace LaunchDarkly.Sdk.Server.Internal.Model
                 }
             );
         }
+    }
+
+    public static class DataSetExtensions
+    {
+        public static string ToJsonString(this FullDataSet<ItemDescriptor> data)
+        {
+            var ob0 = LdValue.BuildObject();
+            foreach (var kv0 in data.Data)
+            {
+                if (kv0.Key == DataModel.Features || kv0.Key == DataModel.Segments)
+                {
+                    var ob1 = LdValue.BuildObject();
+                    foreach (var kv1 in kv0.Value.Items)
+                    {
+                        ob1.Add(kv1.Key, LdValue.Parse(kv0.Key.Serialize(kv1.Value)));
+                    }
+                    ob0.Add(kv0.Key == DataModel.Features ? "flags" : "segments", ob1.Build());
+                }
+            }
+            return ob0.Build().ToJsonString();
+        }
+
+        internal static string ToJsonString(this FeatureFlag item) => DataModel.Features.Serialize(DescriptorOf(item));
+
+        internal static string ToJsonString(this Segment item) => DataModel.Segments.Serialize(DescriptorOf(item));
     }
 }

--- a/test/LaunchDarkly.ServerSdk.Tests/LdClientListenersTest.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/LdClientListenersTest.cs
@@ -254,7 +254,12 @@ namespace LaunchDarkly.Sdk.Server
                 storeMock.SetupMetadataThrows(new Exception("sorry"));
 
                 var status2 = statuses.ExpectValue();
-                Assert.False(status2.Available);
+                if (status2.Available)
+                {
+                    // depending on timing, we might or might not receive an initial update of Available = true
+                    status2 = statuses.ExpectValue();
+                    Assert.False(status2.Available);
+                }
             }
         }
 

--- a/test/LaunchDarkly.ServerSdk.Tests/MockResponses.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/MockResponses.cs
@@ -1,0 +1,30 @@
+﻿using LaunchDarkly.Sdk.Server.Internal.Model;
+using LaunchDarkly.TestHelpers.HttpTest;
+
+using static LaunchDarkly.Sdk.Server.Interfaces.DataStoreTypes;
+
+namespace LaunchDarkly.Sdk.Server
+{
+    public static class MockResponses
+    {
+        public static Handler Error401Response => Handlers.Status(401);
+
+        public static Handler Error503Response => Handlers.Status(503);
+
+        public static Handler EventsAcceptedResponse => Handlers.Status(202);
+
+        public static Handler PollingResponse(FullDataSet<ItemDescriptor>? data = null) =>
+            Handlers.BodyJson((data ?? DataSetBuilder.Empty).ToJsonString());
+
+        public static Handler StreamWithInitialData(FullDataSet<ItemDescriptor>? data = null) =>
+            Handlers.SSE.Start()
+                .Then(PutEvent(data))
+                .Then(Handlers.SSE.LeaveOpen());
+
+        public static Handler PutEvent(FullDataSet<ItemDescriptor>? data = null) =>
+            Handlers.SSE.Event(
+                "put",
+                @"{""data"":" + (data ?? DataSetBuilder.Empty).ToJsonString() + "}"
+                );
+    }
+}

--- a/test/LaunchDarkly.ServerSdk.Tests/TestHttpUtils.cs
+++ b/test/LaunchDarkly.ServerSdk.Tests/TestHttpUtils.cs
@@ -1,10 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using LaunchDarkly.Logging;
+using LaunchDarkly.Sdk.Server.Interfaces;
+using LaunchDarkly.TestHelpers.HttpTest;
+using Xunit;
 
 namespace LaunchDarkly.Sdk.Server
 {
@@ -24,7 +26,7 @@ namespace LaunchDarkly.Sdk.Server
                 _body = body;
                 _contentType = contentType;
             }
-    
+
             internal static StubMessageHandler EmptyPollingResponse() =>
                 new StubMessageHandler(HttpStatusCode.OK, "{}", "application/json");
 
@@ -40,6 +42,97 @@ namespace LaunchDarkly.Sdk.Server
                     resp.Content = new StringContent(_body, System.Text.Encoding.UTF8, _contentType);
                 }
                 return Task.FromResult(new HttpResponseMessage(_status));
+            }
+        }
+
+        internal class MessageHandlerThatAddsPathSuffix : HttpClientHandler
+        {
+            private readonly string _suffix;
+
+            internal MessageHandlerThatAddsPathSuffix(string suffix) { _suffix = suffix; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                request.RequestUri = new Uri(request.RequestUri.ToString() + _suffix);
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        // Used for TestWithSpecialHttpConfigurations
+        public delegate void HttpConfigurationTestAction(Uri targetUri, IHttpConfigurationFactory httpConfig, HttpServer server);
+
+        /// <summary>
+        /// A test suite for all SDK components that support our standard HTTP configuration options.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Although all of our supported HTTP behaviors are implemented in shared code, there is no
+        /// guarantee that all of our components are using that code, or using it correctly. So we
+        /// should run this test suite on each component that can be affected by HttpConfigurationBuilder
+        /// properties.
+        /// </para>
+        /// <para>
+        /// For each HTTP configuration variant that is expected work (e.g., using a proxy server), it
+        /// sets up a server that will produce whatever expected response was specified in
+        /// <paramref name="responseHandler"/>. Then it runs <paramref name="testActionShouldSucceed"/>,
+        /// which should create its component with the given configuration and base URI and verify that
+        /// the component behaves correctly.
+        /// </para>
+        /// </remarks>
+        /// <param name="responseHandler">specifies how the target server should response</param>
+        /// <param name="testActionShouldSucceed">verifies the result of a test</param>
+        /// <param name="log">the current TestLogger</param>
+        public static void TestWithSpecialHttpConfigurations(
+            Handler responseHandler,
+            HttpConfigurationTestAction testActionShouldSucceed,
+            Logger log
+            )
+        {
+            log.Info("*** TestHttpClientCanUseCustomMessageHandler");
+            TestHttpClientCanUseCustomMessageHandler(responseHandler, testActionShouldSucceed);
+
+            log.Info("*** TestHttpClientCanUseProxy");
+            TestHttpClientCanUseProxy(responseHandler, testActionShouldSucceed);
+        }
+
+        static void TestHttpClientCanUseCustomMessageHandler(Handler responseHandler,
+            HttpConfigurationTestAction testActionShouldSucceed)
+        {
+            // To verify that a custom HttpMessageHandler will really be used if provided, we
+            // create one that behaves normally except that it modifies the request path.
+            // Then we verify that the server received a request with a modified path.
+
+            var recordAndDelegate = Handlers.Record(out var recorder).Then(responseHandler);
+            using (var server = HttpServer.Start(recordAndDelegate))
+            {
+                var suffix = "/modified-by-test";
+                var messageHandler = new MessageHandlerThatAddsPathSuffix(suffix);
+                var httpConfig = Components.HttpConfiguration().MessageHandler(messageHandler);
+
+                testActionShouldSucceed(server.Uri, httpConfig, server);
+
+                var request = recorder.RequireRequest();
+                Assert.EndsWith(suffix, request.Path);
+                recorder.RequireNoRequests(TimeSpan.FromMilliseconds(100));
+            }
+        }
+
+        static void TestHttpClientCanUseProxy(Handler responseHandler,
+            HttpConfigurationTestAction testActionShouldSucceed)
+        {
+            // To verify that a web proxy will really be used if provided, we set up a proxy
+            // configuration pointing to our test server. It's not really a proxy server,
+            // but if it receives a request that was intended for some other URI (instead of
+            // the SDK trying to access that other URI directly), then that's a success.
+
+            using (var server = HttpServer.Start(responseHandler))
+            {
+                var proxy = new WebProxy(server.Uri);
+                var httpConfig = Components.HttpConfiguration().Proxy(proxy);
+                var fakeBaseUri = new Uri("http://not-a-real-host");
+
+                testActionShouldSucceed(fakeBaseUri, httpConfig, server);
             }
         }
     }


### PR DESCRIPTION
## [6.3.1] - 2021-10-28
### Fixed:
- The `HttpConfigurationBuilder` methods `Proxy` and `ConnectTimeout` were not working correctly: they were being applied to polling requests and analytics event posts, but not streaming requests. Now they apply to all requests. ([#148](https://github.com/launchdarkly/dotnet-server-sdk/issues/148))